### PR TITLE
update microservices demo url

### DIFF
--- a/content/050_modules/module_1.md
+++ b/content/050_modules/module_1.md
@@ -244,6 +244,10 @@ To opt a service into L7 log collection, you need to annotate the service with `
     # try to ping any of the IPs in from the feodo tracker list
     IP=$(kubectl get globalnetworkset threatfeed.feodo-tracker -ojson | jq .spec.nets[0] | sed -e 's/^"//' -e 's/"$//' -e 's/\/32//')
     kubectl -n dev exec -t centos -- sh -c "ping -c1 $IP"
+
+    # example using alienvault threatfeed in Calico Cloud
+    IP=$(kubectl get globalnetworksets -l feed=otx-ipthreatfeed -ojson | jq .items[0].spec.nets[0] | sed -e 's/^"//' -e 's/"$//' -e 's/\/32//')
+    kubectl -n dev exec -t centos -- sh -c "curl -S -m2 $IP 2>/dev/null"
     ```
 
 ## Secure egress access for specific workloads

--- a/content/050_modules/module_1.md
+++ b/content/050_modules/module_1.md
@@ -46,7 +46,7 @@ We will work with resources located in the `tigera-eks-workshop` repository that
     kubectl apply -f demo/dev/app.manifests.yaml
 
     # deploy boutiqueshop app stack
-    kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/master/release/kubernetes-manifests.yaml
+    kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/release/v0.3.8/release/kubernetes-manifests.yaml
     ```
 
 4. Deploy compliance reports.
@@ -66,6 +66,7 @@ We will work with resources located in the `tigera-eks-workshop` repository that
     kubectl apply -f demo/50-alerts/globalnetworkset.changed.yaml
     kubectl apply -f demo/50-alerts/unsanctioned.dns.access.yaml
     kubectl apply -f demo/50-alerts/unsanctioned.lateral.access.yaml
+    kubectl apply -f demo/50-alerts/boutiqueshop.unsanctioned.access.yaml
     ```
 
 6. *[Bonus task]* Configure *frontend* service for L7 log data collection

--- a/content/050_modules/module_4.md
+++ b/content/050_modules/module_4.md
@@ -44,7 +44,7 @@ Generate Compliance reports for regulatory requirements and policy violations.
     NETWORK_ACCESS_REPORT_NAME='cluster-network-access'
     # for managed clusters you must set ELASTIC_INDEX_SUFFIX var to cluster name in the reporter pod template YAML
     # you can get the managed cluster name from the UI by navigating to Managed Clusters view
-    ELASTIC_INDEX_SUFFIX='<set_managed_cluster_name_here>'    
+    ELASTIC_INDEX_SUFFIX=$(kubectl get deployment -n tigera-intrusion-detection intrusion-detection-controller -ojson | jq -r '.spec.template.spec.containers[0].env[] | select(.name == "CLUSTER_NAME").value')
     # enable if you configured audit logs for EKS cluster and uncommented policy audit reporter job
     # you also need to add variable replacement in the sed command below
     # POLICY_AUDIT_REPORT_NAME='cluster-policy-audit'


### PR DESCRIPTION
*Description of changes:*

Pinned microservices demo to version v0.3.8 as newer version doesn't allow installing `curl` into the `loadgenerator` pod.